### PR TITLE
ci: add typecheck, build and test workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,46 @@
+# Build, typecheck and test the SDK on every push and pull request.
+#
+# This repository had no CI at all: it ships a TypeScript SDK that downstream
+# users build against, and its 184 tests had never been run automatically.
+#
+# `npm run lint` is deliberately not a step here. ESLint 9 is a declared
+# dependency but the repository has no eslint config file of any kind, so the
+# script cannot run at all. Choosing a ruleset is a maintainer's decision, and
+# a CI job that is red on arrival teaches people to ignore the whole workflow.
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+permissions:
+  contents: read
+
+jobs:
+  build:
+    name: Build and test
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Install Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+
+      - name: Install dependencies
+        # `ci` rather than `install`, so the lockfile is authoritative and a
+        # dependency cannot drift underneath the build.
+        run: npm ci
+
+      - name: Typecheck
+        run: npm run typecheck
+
+      - name: Build
+        run: npm run build
+
+      - name: Test
+        run: npm test


### PR DESCRIPTION
This repository has no CI. It ships a TypeScript SDK that downstream users build against, and **its 184 tests have never been run automatically.**

One of seven repos in the org with no `.github/workflows` at all — the Elixir, Go, Haskell, Kotlin, Python and TypeScript SDKs plus `zentinel-agent-policy`. `gh run list` returns empty for these, which reads as red in a CI sweep but actually means *never ran*. The Go SDK got the same treatment in zentinelproxy/zentinel-agent-go-sdk#1.

## What it adds

Typecheck, build and test on push and PR. All three verified passing locally before I wrote the workflow:

```
npm run typecheck   exit 0
npm run build       exit 0
npm test            184 passed (5 files), 371ms
```

`npm ci` rather than `npm install`, so the lockfile is authoritative and a dependency can't drift underneath the build.

## Why `lint` is not a step

ESLint 9 is a declared devDependency, but the repository has **no eslint config file of any kind** — not a flat config, not a legacy `.eslintrc`:

```
ESLint: 9.39.2
ESLint couldn't find an eslint.config.(js|mjs|cjs) file.
```

So `npm run lint` has never been capable of running. The script is in `package.json`, the dependency installs, and nothing happens.

I have not added a config, because choosing a ruleset is a maintainer's decision — the same reason the Go SDK PR didn't pick a `golangci` config. And adding the step without a config would make the job red on arrival, which teaches people to ignore the whole workflow.

Worth fixing separately though: **a lint script that has never been able to execute is indistinguishable from having no linter**, and right now the repo looks like it has one.

## Remaining

`python-sdk` (real test suite, needs a venv), `elixir-sdk` (`mix.exs`), `kotlin-sdk` and `policy` (no toolchain available to me), `haskell-sdk` (no standard build file at top level). I'd rather verify each locally than commit workflows I can't run.
